### PR TITLE
Update references to RFC9110

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -393,11 +393,11 @@ span.cancast:hover { background-color: #ffa;
         <dl>
           <dt>SPARQL Protocol client</dt>
           <dd>An HTTP client (as defined by
-            <a data-cite="rfc9110#section-3.3">Section 3.3. Connections, Clients, and
+            <a data-cite="rfc9110#connections">Section 3.3. Connections, Clients, and
             Servers</a> of [[[RFC9110]]] [[RFC9110]]) that sends HTTP requests for
             SPARQL Protocol operations. (Also known as: <em>client</em>.)</dd>
 
-          <dd>An HTTP client (as defined by <a data-cite="rfc9110#section-3.3">RFC 9110</a> [[RFC9110]]) that sends HTTP requests for SPARQL
+          <dd>An HTTP client (as defined by <a data-cite="rfc9110#connections">RFC 9110</a> [[RFC9110]]) that sends HTTP requests for SPARQL
           Protocol operations. (Also known as: <em>client</em>)</dd>
           <dt>SPARQL Protocol service</dt>
           <dd>An HTTP server that services HTTP requests and sends back HTTP responses for SPARQL Protocol operations. The URI at which a SPARQL Protocol service listens for requests is generally
@@ -427,7 +427,7 @@ span.cancast:hover { background-color: #ffa;
         GET or HTTP POST method. Client requests for this operation <strong>must</strong> include exactly one SPARQL query string (parameter name: <code>query</code>) and <strong>may</strong> include
         zero or more default graph URIs (parameter name: <code>default-graph-uri</code>) and named graph URIs (parameter name: <code>named-graph-uri</code>). The response to a query request is either
         the [[[SPARQL12-RESULTS-XML]]], the [[[SPARQL12-RESULTS-JSON]]], the [[[SPARQL12-RESULTS-CSV-TSV]]], or an RDF serialization, depending on the <a data-cite="SPARQL12-QUERY#QueryForms">query
-        form</a> and <a data-cite="rfc9110#section-12">content negotiation</a> [[RFC9110]].
+        form</a> and <a data-cite="rfc9110#content.negotiation">content negotiation</a> [[RFC9110]].
         </p>
         <span class="doc-ref" id="query-summary"></span>
         <table style="margin-left: auto; margin-right: auto; border-color: rgb(0, 0, 0); border-collapse: collapse; padding: 5px; border: 1px">
@@ -503,12 +503,12 @@ span.cancast:hover { background-color: #ffa;
         </section>
         <section id="conneg">
           <h4>Accepted Response Formats</h4>
-          <p>Protocol clients <strong>should</strong> use HTTP <a data-cite="rfc9110#name-content-negotiation">content negotiation</a> [[RFC9110]] to request
+          <p>Protocol clients <strong>should</strong> use HTTP <a data-cite="rfc9110#content.negotiation">content negotiation</a> [[RFC9110]] to request
           response formats that the client can consume. See below for more on potential response formats.</p>
         </section>
         <section id="query-success">
           <h4>Success Responses</h4>
-          <p>The SPARQL Protocol uses the response status codes defined in HTTP to indicate the success or failure of an operation. Consult the <a data-cite="rfc9110#section-15">HTTP specification</a> 
+          <p>The SPARQL Protocol uses the response status codes defined in HTTP to indicate the success or failure of an operation. Consult the <a data-cite="rfc9110#status.codes">HTTP specification</a> 
           [[RFC9110]] for detailed definitions of each status code. While a protocol service
           <strong>should</strong> use a 2XX HTTP response code for a successful query, it <strong>may</strong> choose instead to use a 3XX response code as per HTTP.</p>
           <p>The response body of a successful query operation with a 2XX response is either:</p>
@@ -601,7 +601,7 @@ span.cancast:hover { background-color: #ffa;
         </section>
         <section id="update-success">
           <h4>Success Responses</h4>
-          <p>The SPARQL Protocol uses the response status codes defined in HTTP to indicate the success or failure of an operation. Consult the <a data-cite="rfc9110#section-15">HTTP specification</a> 
+          <p>The SPARQL Protocol uses the response status codes defined in HTTP to indicate the success or failure of an operation. Consult the <a data-cite="rfc9110#status.codes">HTTP specification</a> 
           [[RFC9110]] for detailed definitions of each status code. While a protocol service
           <strong>should</strong> use a <code>2XX</code> HTTP response code for an update request that is successfully processed, it <strong>may</strong> choose instead to use a <code>3XX</code> 
           response code as per HTTP.</p>


### PR DESCRIPTION
ReSpec and Specref now use the `https://httpwg.org/specs/` version for RFC9110, as it is more readable. Unfortunately, the fragment identifiers are not the same in that version and need to be updated.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/sparql-protocol/pull/24.html" title="Last updated on Nov 24, 2023, 2:57 PM UTC (96850ab)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-protocol/24/62ba29f...tidoust:96850ab.html" title="Last updated on Nov 24, 2023, 2:57 PM UTC (96850ab)">Diff</a>