### PR TITLE
Migrate from quoted triples to reified triples

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1219,14 +1219,14 @@ Content-Type: application/sparql-results+xml
 &lt;/sparql&gt;</pre>
           </div>
         </section>
-        <section id="select-triple-terms">
-          <h4>SELECT with triple term patterns</h4>
-          <p>SPARQL queries can target triple terms. This SPARQL query</p>
-          <div id="div-select-triple-terms">
+        <section id="select-reified-triples">
+          <h4>SELECT with reified triple patterns</h4>
+          <p>SPARQL queries can target reified triples. This SPARQL query</p>
+          <div id="div-select-reified-triple">
             <pre class="query nohighlight">PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;
 PREFIX ex: &lt;http://example.org/&gt;
 SELECT ?name ?person
-WHERE { &lt;&lt;( _:a foaf:name ?name )&gt;&gt; ex:statedBy ?person . }</pre>
+WHERE { &lt;&lt; _:a foaf:name ?name &gt;&gt; ex:statedBy ?person . }</pre>
             <p>is conveyed to the SPARQL query service, <code>http://www.example/sparql/</code>, as illustrated in this HTTP trace:</p>
             <pre class="req nohighlight">GET /sparql/?<b>query=PREFIX%20foaf%3A%20%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%0APREFIX%20ex%3A%20%3Chttp%3A%2F%2Fexample.org%2F%3E%0ASELECT%20%3Fname%20%3Fperson%0AWHERE%20%7B%20%3C%3C%28%20_%3Aa%20foaf%3Aname%20%3Fname%20%29%3E%3E%20ex%3AstatedBy%20%3Fperson%20.%20%7D</b>
 Host: www.example
@@ -1384,7 +1384,7 @@ WHERE { GRAPH ?g { ?person ?property ?value ; foaf:givenName 'Fred' } }</pre>
       <p>This specification extends and updates the <a href="https://www.w3.org/TR/2013/REC-sparql11-protocol-20130321/">SPARQL 1.1 Protocol of March, 2013</a>. The significant changes
       are:</p>
       <ul>
-        <li>Add informative example of triple terms</li>
+        <li>Add informative example of reified triples</li>
         <li>Improve display on mobile phones</li>
         <li>Add explicit references to RFCs</li>
       </ul>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1219,16 +1219,16 @@ Content-Type: application/sparql-results+xml
 &lt;/sparql&gt;</pre>
           </div>
         </section>
-        <section id="select-quoted">
-          <h4>SELECT with quoted triple patterns</h4>
-          <p>SPARQL queries can target quoted triples. This SPARQL query</p>
-          <div id="div-select-quoted">
+        <section id="select-triple-terms">
+          <h4>SELECT with triple term patterns</h4>
+          <p>SPARQL queries can target triple terms. This SPARQL query</p>
+          <div id="div-select-triple-terms">
             <pre class="query nohighlight">PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;
 PREFIX ex: &lt;http://example.org/&gt;
 SELECT ?name ?person
-WHERE { &lt;&lt; _:a foaf:name ?name &gt;&gt; ex:statedBy ?person . }</pre>
+WHERE { &lt;&lt;( _:a foaf:name ?name )&gt;&gt; ex:statedBy ?person . }</pre>
             <p>is conveyed to the SPARQL query service, <code>http://www.example/sparql/</code>, as illustrated in this HTTP trace:</p>
-            <pre class="req nohighlight">GET /sparql/?<b>query=PREFIX%20foaf%3A%20%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%0APREFIX%20ex%3A%20%3Chttp%3A%2F%2Fexample.org%2F%3E%0ASELECT%20%3Fname%20%3Fperson%20%0AWHERE%20%7B%20%3C%3C%20_%3Aa%20foaf%3Aname%20%3Fname%20%3E%3E%20ex%3AstatedBy%20%3Fperson%20.%20%7D</b>
+            <pre class="req nohighlight">GET /sparql/?<b>query=PREFIX%20foaf%3A%20%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%0APREFIX%20ex%3A%20%3Chttp%3A%2F%2Fexample.org%2F%3E%0ASELECT%20%3Fname%20%3Fperson%0AWHERE%20%7B%20%3C%3C%28%20_%3Aa%20foaf%3Aname%20%3Fname%20%29%3E%3E%20ex%3AstatedBy%20%3Fperson%20.%20%7D</b>
 Host: www.example
 User-agent: sparql-client/0.1</pre>
             <pre class="resp nohighlight">HTTP/1.1 200 OK
@@ -1384,7 +1384,7 @@ WHERE { GRAPH ?g { ?person ?property ?value ; foaf:givenName 'Fred' } }</pre>
       <p>This specification extends and updates the <a href="https://www.w3.org/TR/2013/REC-sparql11-protocol-20130321/">SPARQL 1.1 Protocol of March, 2013</a>. The significant changes
       are:</p>
       <ul>
-        <li>Add informative quoted triples example</li>
+        <li>Add informative triple terms example</li>
         <li>Improve display on mobile phones</li>
         <li>Add explicit references to RFCs</li>
       </ul>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1384,7 +1384,7 @@ WHERE { GRAPH ?g { ?person ?property ?value ; foaf:givenName 'Fred' } }</pre>
       <p>This specification extends and updates the <a href="https://www.w3.org/TR/2013/REC-sparql11-protocol-20130321/">SPARQL 1.1 Protocol of March, 2013</a>. The significant changes
       are:</p>
       <ul>
-        <li>Add informative triple terms example</li>
+        <li>Add informative example of triple terms</li>
         <li>Improve display on mobile phones</li>
         <li>Add explicit references to RFCs</li>
       </ul>


### PR DESCRIPTION
Following the changes in https://github.com/w3c/rdf-concepts/commit/6b7ea76dccfa4ec0d5c9b94cdce7d22dcc0536e5, this PR uses triple terms instead of quoted triples.

Related to https://github.com/w3c/sparql-query/pull/149


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-protocol/pull/27.html" title="Last updated on Aug 23, 2024, 6:08 AM UTC (06cd79d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-protocol/27/72e262b...06cd79d.html" title="Last updated on Aug 23, 2024, 6:08 AM UTC (06cd79d)">Diff</a>