### PR TITLE
Fix intro section nesting

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -369,9 +369,10 @@ span.cancast:hover { background-color: #ffa;
         <a href="https://www.w3.org/groups/wg/rdf-star">RDF Star Working Group</a> as part of the
         update of specifications for format and errata.
       </p>
-    </section>
 
-    <section id="related" data-include="./common/sparql-related.html"></section>
+      <section id="related" data-include="./common/sparql-related.html"></section>
+
+    </section>
 
 <!-- BODY -->
     <section id="intro">


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-protocol/pull/29.html" title="Last updated on Nov 9, 2024, 2:04 PM UTC (3042b3a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-protocol/29/1da9ab5...3042b3a.html" title="Last updated on Nov 9, 2024, 2:04 PM UTC (3042b3a)">Diff</a>