### PR TITLE
Adds dark mode and simplify CSS

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -187,8 +187,8 @@
         </ul>
 
         <span class="doc-ref" id="query-summary"></span>
-        <table style="margin-left: auto; margin-right: auto; border-color: rgb(0, 0, 0); border-collapse: collapse; padding: 5px; border: 1px">
-          <tbody>
+        <table class="data">
+          <thead>
             <tr>
               <th>&nbsp;</th>
               <th>HTTP Method</th>
@@ -196,6 +196,8 @@
               <th>Request Content Type</th>
               <th>Request Message Body</th>
             </tr>
+          </thead>
+          <tbody>
             <tr>
               <th>query via GET</th>
               <td>GET</td>
@@ -302,8 +304,8 @@
           URIs (parameter name: <code>using-graph-uri</code>) and named graph URIs (parameter name: <code>using-named-graph-uri</code>). The response to an update request indicates success or failure
           of the request via HTTP response status code.</p>
         <span class="doc-ref" id="update-summary"></span>
-        <table style="margin-left: auto; margin-right: auto; border-color: rgb(0, 0, 0); border-collapse: collapse; padding: 5px; border: 1px">
-          <tbody>
+        <table class="data">
+          <thead>
             <tr>
               <th>&nbsp;</th>
               <th>HTTP Method</th>
@@ -311,6 +313,8 @@
               <th>Request Content Type</th>
               <th>Request Message Body</th>
             </tr>
+          </thead>
+          <tbody>
             <tr>
               <th>update via URL-encoded POST</th>
               <td>POST</td>
@@ -408,7 +412,7 @@
 SELECT ?book ?who 
 WHERE { ?book dc:creator ?who }</pre>
             <p>is conveyed via HTTP GET to the SPARQL query service, <code>http://www.example/sparql/</code>, as illustrated in this HTTP trace:</p>
-            <pre class="req nohighlight">GET /sparql/<b>?query=</b>PREFIX%20dc%3A%20%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Felements%2F1.1%2F%3E%20%0ASELECT%20%3Fbook%20%3Fwho%20%0AWHERE%20%7B%20%3Fbook%20dc%3Acreator%20%3Fwho%20%7D%0A HTTP/1.1
+            <pre class="http">GET /sparql/?query=PREFIX%20dc%3A%20%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Felements%2F1.1%2F%3E%20%0ASELECT%20%3Fbook%20%3Fwho%20%0AWHERE%20%7B%20%3Fbook%20dc%3Acreator%20%3Fwho%20%7D%0A HTTP/1.1
 Host: www.example
 User-agent: my-sparql-client/0.1</pre>
             <p>That query against the service-supplied RDF Dataset, executed by that SPARQL query service, returns the following query result:</p>
@@ -442,7 +446,7 @@ Content-Type: application/sparql-results+xml
 SELECT ?book ?who 
 WHERE { ?book dc:creator ?who }</pre>
             <p>is conveyed to the SPARQL query service, <code>http://www.other.example/sparql/</code>, as illustrated in this HTTP trace:</p>
-            <pre class="req nohighlight">GET /sparql/<b>?query=</b>PREFIX%20dc%3A%20%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Felements%2F1.1%2F%3E%20%0ASELECT%20%3Fbook%20%3Fwho%20%0AWHERE%20%7B%20%3Fbook%20dc%3Acreator%20%3Fwho%20%7D%0A<b>&amp;default-graph-uri=</b>http%3A%2F%2Fwww.other.example%2Fbooks HTTP/1.1
+            <pre class="http">GET /sparql/?query=PREFIX%20dc%3A%20%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Felements%2F1.1%2F%3E%20%0ASELECT%20%3Fbook%20%3Fwho%20%0AWHERE%20%7B%20%3Fbook%20dc%3Acreator%20%3Fwho%20%7D%0A&amp;default-graph-uri=http%3A%2F%2Fwww.other.example%2Fbooks HTTP/1.1
 Host: www.other.example
 User-agent: my-sparql-client/0.1
 </pre>
@@ -481,7 +485,7 @@ WHERE { ?s ?p ?o. myfoaf:jose foaf:nick "Jo".
               &amp;&amp; ! ( ?s = myfoaf:julia &amp;&amp; ?p = rdf:type &amp;&amp; ?o = foaf:Person))
 }</pre>
             <p>is conveyed to the SPARQL query service, <code>http://www.example/sparql/</code>, as illustrated in this HTTP trace:</p>
-            <pre class="req nohighlight">GET /sparql/<b>?query=</b><i>EncodedQuery</i><b>&amp;default-graph-uri=</b>http%3A%2F%2Fwww.example%2Fjose-foaf.rdf HTTP/1.1
+            <pre class="http">GET /sparql/?query=<i>EncodedQuery</i>&amp;default-graph-uri=http%3A%2F%2Fwww.example%2Fjose-foaf.rdf HTTP/1.1
 Host: www.example
 User-agent: sparql-client/0.1
 Accept: text/turtle, application/rdf+xml</pre>
@@ -509,7 +513,7 @@ myfoaf:jose foaf:name "Jose Jimeñez";
             <pre class="sparql">PREFIX dc: &lt;http://purl.org/dc/elements/1.1/&gt;
 ASK WHERE { ?book dc:creator "J.K. Rowling"}</pre>
             <p>is conveyed to the SPARQL query service, <code>http://www.example/sparql/</code>, as illustrated in this HTTP trace:</p>
-            <pre class="req nohighlight">GET /sparql/<b>?query=</b><i>EncodedQuery</i><b>&amp;default-graph-uri=</b>http%3A%2F%2Fwww.example%2Fbooks HTTP/1.1
+            <pre class="http">GET /sparql/?query=<i>EncodedQuery</i>&amp;default-graph-uri=http%3A%2F%2Fwww.example%2Fbooks HTTP/1.1
 Host: www.example
 User-agent: sparql-client/0.1
 </pre>
@@ -534,7 +538,7 @@ Content-Type: application/sparql-results+xml
             <pre class="sparql">PREFIX books: &lt;http://www.example/book/&gt;
 DESCRIBE books:book6</pre>
             <p>is conveyed to the SPARQL query service, <code>http://www.example/sparql/</code>, as illustrated here:</p>
-            <pre class="req nohighlight">GET /sparql/<b>?query=</b><i>EncodedQuery</i><b>&amp;default-graph-uri=</b>http%3A%2F%2Fwww.example%2Fbooks HTTP/1.1
+            <pre class="http">GET /sparql/?query=<i>EncodedQuery</i>&amp;default-graph-uri=http%3A%2F%2Fwww.example%2Fbooks HTTP/1.1
 Host: www.example
 User-agent: sparql-client/0.1</pre>
             <p>With the response illustrated here:</p>
@@ -567,10 +571,10 @@ WHERE {  ?g dc:publisher ?who .
    GRAPH ?g { ?x foaf:mbox ?mbox }
 }</pre>
             <p>is conveyed to the SPARQL query service, http://www.example/sparql/, as illustrated here (with line breaks for legibility):</p>
-            <pre class="req nohighlight">GET /sparql/<b>?query=</b><i>EncodedQuery</i><b>&amp;default-graph-uri=</b>http%3A%2F%2Fwww.example%2Fpublishers
-<b>&amp;default-graph-uri=</b>http%3A%2F%2Fwww.example%2Fmorepublishers<b>&amp;named-graph-uri=</b>http%3A%2F%2Fyour.example%2Ffoaf-alice
-<b>&amp;named-graph-uri=</b>http%3A%2F%2Fwww.example%2Ffoaf-bob<b>&amp;named-graph-uri=</b>http%3A%2F%2Fwww.example%2Ffoaf-susan
-<b>&amp;named-graph-uri=</b>http%3A%2F%2Fthis.example%2Fjohn%2Ffoaf
+            <pre class="http">GET /sparql/?query=<i>EncodedQuery</i>&amp;default-graph-uri=http%3A%2F%2Fwww.example%2Fpublishers
+&amp;default-graph-uri=http%3A%2F%2Fwww.example%2Fmorepublishers&amp;named-graph-uri=http%3A%2F%2Fyour.example%2Ffoaf-alice
+&amp;named-graph-uri=http%3A%2F%2Fwww.example%2Ffoaf-bob&amp;named-graph-uri=http%3A%2F%2Fwww.example%2Ffoaf-susan
+&amp;named-graph-uri=http%3A%2F%2Fthis.example%2Fjohn%2Ffoaf
 Host: www.example
 User-agent: sparql-client/0.1</pre>
             <p>With the response illustrated here:</p>
@@ -606,7 +610,7 @@ WHERE { ?g dc:publisher ?who .
         GRAPH ?g { ?x foaf:mbox ?mbox }
 }</pre>
             <p>is conveyed to the SPARQL query service, <code>http://www.example/sparql/</code>, as illustrated in this HTTP trace:</p>
-            <pre class="req nohighlight">GET /sparql/<b>?query=</b><i>EncodedQuery</i> HTTP/1.1
+            <pre class="http">GET /sparql/?query=<i>EncodedQuery</i> HTTP/1.1
 Host: www.example
 User-agent: sparql-client/0.1</pre>
             <p>With the response illustrated here:</p>
@@ -637,8 +641,8 @@ WHERE { ?g dc:publisher ?who .
         GRAPH ?g { ?x foaf:mbox ?mbox }
 }</pre>
             <p>is conveyed to the SPARQL query service, <code>http://www.example/sparql/</code>, as illustrated in this HTTP trace:</p>
-            <pre class="req nohighlight">GET /sparql/<b>?query=</b><i>EncodedQuery</i><b>&amp;default-graph-uri=</b>http%3A%2F%2Fwww.example%2Fmorepublishers
-<b>&amp;named-graph-uri=</b>http%3A%2F%2Fwww.example%2Fbob<b>&amp;named-graph-uri=</b>http%3A%2F%2Fwww.example%2Falice HTTP/1.1
+            <pre class="http">GET /sparql/?query=<i>EncodedQuery</i>&amp;default-graph-uri=http%3A%2F%2Fwww.example%2Fmorepublishers
+&amp;named-graph-uri=http%3A%2F%2Fwww.example%2Fbob&amp;named-graph-uri=http%3A%2F%2Fwww.example%2Falice HTTP/1.1
 Host: www.example
 User-agent: sparql-client/0.1</pre>
             <p>This protocol operation contains an ambiguous RDF Dataset: the dataset specified in the query is different than the one specified in the protocol (by way of
@@ -693,7 +697,7 @@ SELECT ?name
 WHERE { ?x foaf:name ?name
 ORDER BY ?name }</pre>
             <p>is conveyed to the SPARQL query service, <code>http://www.example/sparql/</code>, as illustrated in this HTTP trace:</p>
-            <pre class="req nohighlight">GET /sparql/<b>?query=</b><i>EncodedQuery</i><b>&amp;default-graph-uri=</b>http%3A%2F%2Fwww.example%2Fmorepublishers HTTP/1.1
+            <pre class="http">GET /sparql/?query=<i>EncodedQuery</i>&amp;default-graph-uri=http%3A%2F%2Fwww.example%2Fmorepublishers HTTP/1.1
 Host: www.example
 User-agent: sparql-client/0.1</pre>
             <p>With the error response illustrated here:</p>
@@ -716,7 +720,7 @@ FROM &lt;http://another.example/protein-db.rdf&gt;
 WHERE { ?x bio:protein ?valence }
 ORDER BY ?valence</pre>
             <p>is conveyed to the SPARQL query service, <code>http://www.example/sparql/</code>, as illustrated in this HTTP trace:</p>
-            <pre class="req nohighlight">GET /sparql/<b>?query=</b><i>EncodedQuery</i><b>&amp;default-graph-uri=</b>http%3A%2F%2Fanother.example%2Fprotein-db.rdf HTTP/1.1
+            <pre class="http">GET /sparql/?query=<i>EncodedQuery</i>&amp;default-graph-uri=http%3A%2F%2Fanother.example%2Fprotein-db.rdf HTTP/1.1
 Host: www.example
 User-agent: sparql-client/0.1</pre>
             <p>With the error response illustrated here:</p>
@@ -905,7 +909,7 @@ User-agent: sparql-client/0.1
 Content-Type: application/x-www-form-urlencoded
 Content-Length: 9461
 
-<b>query=</b><i>EncodedQuery</i><b>&amp;default-graph-uri=</b>http%3A%2F%2Fanother.example%2Fcalendar.rdf</pre>
+query=<i>EncodedQuery</i>&amp;default-graph-uri=http%3A%2F%2Fanother.example%2Fcalendar.rdf</pre>
             <p>With the response illustrated here:</p>
             <pre class="http">HTTP/1.1 200 OK
 Date: Wed, 03 Aug 2005 12:48:25 GMT
@@ -965,7 +969,7 @@ PREFIX 食: &lt;http://www.w3.org/2001/sw/DataAccess/tests/data/i18n/kanji.ttl#&
 SELECT ?name ?food 
 WHERE { [ foaf:name ?name ; 食:食べる ?food ] . }</pre>
             <p>is conveyed to the SPARQL query service, <code>http://www.example/sparql/</code>, as illustrated in this HTTP trace:</p>
-            <pre class="req nohighlight">GET /sparql/<b>?query=</b>PREFIX%20foaf%3A%20%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%0APREFIX%20%E9%A3%9F%3A%20%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2Fsw%2FDataAccess%2Ftests%2Fdata%2Fi18n%2Fkanji.ttl%23%3E%0ASELECT%20%3Fname%20%3Ffood%20%0AWHERE%20%7B%20%5B%20foaf%3Aname%20%3Fname%20%3B%20%E9%A3%9F%3A%E9%A3%9F%E3%81%B9%E3%82%8B%20%3Ffood%20%5D%20.%20%7D
+            <pre class="http">GET /sparql/?query=PREFIX%20foaf%3A%20%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%0APREFIX%20%E9%A3%9F%3A%20%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2Fsw%2FDataAccess%2Ftests%2Fdata%2Fi18n%2Fkanji.ttl%23%3E%0ASELECT%20%3Fname%20%3Ffood%20%0AWHERE%20%7B%20%5B%20foaf%3Aname%20%3Fname%20%3B%20%E9%A3%9F%3A%E9%A3%9F%E3%81%B9%E3%82%8B%20%3Ffood%20%5D%20.%20%7D
 Host: www.example
 User-agent: sparql-client/0.1</pre>
             <pre class="http">HTTP/1.1 200 OK
@@ -989,7 +993,7 @@ PREFIX ex: &lt;http://example.org/&gt;
 SELECT ?name ?person
 WHERE { &lt;&lt; _:a foaf:name ?name &gt;&gt; ex:statedBy ?person . }</pre>
             <p>is conveyed to the SPARQL query service, <code>http://www.example/sparql/</code>. Since the query is using SPARQL 1.2 syntax, and the query does not announce the 1.2 version syntactically, the GET request is issued using the <code>version=1.2</code> parameter. This is illustrated in this HTTP trace:</p>
-            <pre class="req nohighlight">GET /sparql/<b>?query=</b>PREFIX%20foaf%3A%20%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%0APREFIX%20ex%3A%20%3Chttp%3A%2F%2Fexample.org%2F%3E%0ASELECT%20%3Fname%20%3Fperson%0AWHERE%20%7B%20%3C%3C%28%20_%3Aa%20foaf%3Aname%20%3Fname%20%29%3E%3E%20ex%3AstatedBy%20%3Fperson%20.%20%7D<b>&version=</b>1.2
+            <pre class="http">GET /sparql/?query=PREFIX%20foaf%3A%20%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%0APREFIX%20ex%3A%20%3Chttp%3A%2F%2Fexample.org%2F%3E%0ASELECT%20%3Fname%20%3Fperson%0AWHERE%20%7B%20%3C%3C%28%20_%3Aa%20foaf%3Aname%20%3Fname%20%29%3E%3E%20ex%3AstatedBy%20%3Fperson%20.%20%7D&version=1.2
 Host: www.example
 User-agent: sparql-client/0.1</pre>
             <pre class="http">HTTP/1.1 200 OK
@@ -1013,7 +1017,7 @@ PREFIX ex: &lt;http://example.org/&gt;
 SELECT ?statement ?person
 WHERE { ?statement ex:statedBy ?person . FILTER (isTRIPLE(?statement)) }</pre>
           <p>While the query announces its version syntactically, the SPARQL client decides to send the direct POST request using the <code>version=1.2</code> media-type, which is allowed but not required if the version is already announced syntactically. This is illustrated in this HTTP trace:</p>
-          <pre class="req nohighlight">POST /sparql HTTP/1.1
+          <pre class="http">POST /sparql HTTP/1.1
 Host: www.example
 User-agent: sparql-client/0.1
 Content-Type: application/sparql-query; version=1.2
@@ -1044,7 +1048,7 @@ Accept: text/plain
 Content-Length: 62
 Content-Type: application/x-www-form-urlencoded
 
-<b>update=</b>INSERT%20DATA%20%7B%20%3Ca%3E%20%3Cp%3E%20%3Cb%3E%20%7D
+update=INSERT%20DATA%20%7B%20%3Ca%3E%20%3Cp%3E%20%3Cb%3E%20%7D
 </pre>
         </section>
         <section id="update-direct-simple">
@@ -1085,7 +1089,7 @@ Accept: */*
 Content-Type: application/x-www-form-urlencoded
 Content-Length: 130
 
-<b>update=</b>DELETE%20DATA%20%7B%20%3Ca%3E%20%3Cp%3E%20%3Cold%3E%20%7D%20%3B%0AINSERT%20DATA%20%7B%20%3Ca%3E%20%3Cp%3E%20%3Cnew%3E%20%7D</pre>
+update=DELETE%20DATA%20%7B%20%3Ca%3E%20%3Cp%3E%20%3Cold%3E%20%7D%20%3B%0AINSERT%20DATA%20%7B%20%3Ca%3E%20%3Cp%3E%20%3Cnew%3E%20%7D</pre>
         </section>
         <section id="update-urlencoded-multi-dataset">
           <h4>Multi-operation UPDATE specifying dataset and using URL-encoded parameters</h4>
@@ -1101,7 +1105,7 @@ Accept: */*
 Content-Type: application/x-www-form-urlencoded
 Content-Length: 130
 
-<b>using-named-graph-uri=</b>http%3A%2F%2Flocalhost%3A8888%2Falice%2Ffoaf.rdf<b>&amp;using-named-graph-uri=</b>http%3A%2F%2Flocalhost%3A8888%2Feve%2Ffoaf.rdf<b>&amp;update=</b>PREFIX%20foaf%3A%20%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%0AINSERT%20%7B%20GRAPH%20%3Chttp%3A%2F%2Flocalhost%3A8888%2Fpeople%3E%20%7B%20%3Fperson%20%3Fproperty%20%3Fvalue%20%7D%20%7D%0AWHERE%20%7B%20GRAPH%20%3Fg%20%7B%20%3Fperson%20%3Fproperty%20%3Fvalue%20%3B%20foaf%3AgivenName%20%27Fred%27%20%7D%20%7D
+using-named-graph-uri=http%3A%2F%2Flocalhost%3A8888%2Falice%2Ffoaf.rdf&amp;using-named-graph-uri=http%3A%2F%2Flocalhost%3A8888%2Feve%2Ffoaf.rdf&amp;update=PREFIX%20foaf%3A%20%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%0AINSERT%20%7B%20GRAPH%20%3Chttp%3A%2F%2Flocalhost%3A8888%2Fpeople%3E%20%7B%20%3Fperson%20%3Fproperty%20%3Fvalue%20%7D%20%7D%0AWHERE%20%7B%20GRAPH%20%3Fg%20%7B%20%3Fperson%20%3Fproperty%20%3Fvalue%20%3B%20foaf%3AgivenName%20%27Fred%27%20%7D%20%7D
 </pre>
         </section>
         <section id="update-direct-multi-dataset">

--- a/spec/index.html
+++ b/spec/index.html
@@ -2,6 +2,7 @@
 <html lang="en" dir="ltr">
   <head>
     <meta charset="utf-8" />
+    <meta name="color-scheme" content="light dark" />
     <title>SPARQL 1.2 Protocol</title>
 
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
@@ -48,304 +49,6 @@
         lint: { "no-unused-dfns": false }
       };
     </script>
-
-    <style>
-      /* @import url("local.css"); */
-      /* Inlined to make preview work */
-
-/* CSS For SPARQL Query */
-
-/* In-progress working draft artifacts - to be removed eventually */
-  .issue	{ background-color: #fdd;
-                  font-size: 88% ; }
-  .add		{ background-color: #7fff7f }
-  .remove	{ background-color: #ff7f7f }
-ul.issue	{}
-  .issueBlock	{ margin: 1em 4em 1em 2.5em ; /* Top Right Bottom Left */
-                  padding: 1ex;
-	          /*overflow: auto;*/
-                  page-break-inside: avoid ; }
-  .issueTopic	{ font-weight: bold ; }
-
- .todo		{ font-size: 80% ; color: #444 ; }
-p.todo		{}
-
-.wgNote	{ border: 0.2em solid red;
-      padding: 0.5em ;
-      margin: 1em 4em 1em 2em ; }
-
-.box     { border: thin solid #888888;
-           page-break-inside: avoid ;
-           background-color: #F8F8F8 ; padding:1em ;
-           margin-left:0 ; margin-right: 2ex; 
-           margin-top: 0.1ex ; margin-bottom: 0.1ex ;
-         }
-
-/* Misc WD stuff */
-span.cvs-id     {color: gray; font-size:80%; display: block; }
-
-/* == General Tag Treatment == */
-pre		 { margin: 1em 1em 1em 2.5em ; /* Top Right Bottom Left */
-                   padding: 1ex;
-	           /*overflow: auto;*/
-                   page-break-inside: avoid ; }
-
-/* Tables */
-table, td	{ text-align: left; }
-td, th   { border-style: solid;
-                  border-width: 1px;
-                  border-color: black;
-                  border-bottom-color: gray;
-                  border-right-color: gray; }
-td.annotation, th.annotation { border-style: none; border-bottom-style: dotted; }
-table.plain	{ border-spacing: 0px; padding: 0px ; border-collapse: collapse ; }
-                  /* cellpadding="0" cellspacing="1" style="border-collapse: collapse */
-
-
-th.major	{ background-color: #005a9c;
-                  color: white; }
-.subHeading	{ text-align: left;
-                  background-color: #CCCCCC; }
-th, td		{ padding: 3px; }
-td		{ font-size: 85%; }
-th a:link	{ text-decoration: none; }
-th a:hover	{ background-color:#FFFF99;
-                  text-decoration: underline; }
-
-/* == Prototypes == */
-pre.prototype	{ background-color:#f7f8ff;
-                  border:thin solid #8888aa;
-                  margin: 1em 1em 1em 0em ; }
-.return, .type	{ color: #177 }
-
-/* Definitions */
-.defn		{ margin-left:0 ; margin-right: 2ex; 
-                  margin-top: 0.1ex ; margin-bottom: 0.1ex ;
-                  /*border: double 1px #888888; *//* Buggy */
-                  border: thin solid #888888;
-                  padding: 1ex 2ex 0.5ex 2ex ; /* top, right, bottom, left */
-                  page-break-inside: avoid ;
-                  background-color: #F0F8F8 ; }
-div.defn p	{ margin-top: 1ex ; margin-bottom: 1.5ex ;}
-div.defn ul	{ margin-top: 1ex ; margin-bottom: 1.5ex ; }
-@media print	{ .defn { margin: 1em 1em 1em 1em ; } }
-span.definedTerm	{font-weight: bold;}
-
-div.grammarExtract
-                { border: thin solid #888888;
-                  padding: 1ex 2ex 1ex 2ex ; /* top, right, bottom, left */
-                  margin: 1em 6em 1em 2em ; 
-                  page-break-inside: avoid ;
-                  background-color: #F8F8F8 ; }
-
-pre.codeBlock  { font-family:monospace ; page-break-inside: avoid ; 
-                 margin: 0 ;
-	         margin-right: 2ex ;
-                 border: thin solid #888888; }
-
-
-
-
-/* Examples */
-pre.data	{ border: thin solid #88AA88;
-                  background-color: #E8F0E8;
-                  margin: 1em 1em 1em 0em ; }
-
-pre.dataExcerpt	{ border: thin solid #88AA88;
-                  background-color: #E8F0E8;
-                  margin: 1em 1em 1em 0em ; }
-/* Example Queries */
-.query          { background-color:#f7f8ff; }
-.queryExcerpt   { background-color:#f7f8ff; }
-pre.query	{ border:thin solid #8888aa;
-                  margin: 1em 1em 1em 0em ; }
-/* Example Results */
-.result		{ border: thin solid  #888888 ;
-                  background-color: #F0F0F0 ; }
-pre.resultGraph	{  margin: 0em 0em 0em 0em ; /* Top Right Bottom Left */
-                   padding: 0ex;
-                   font-size: 100% ;
-                   page-break-inside: avoid ; }
-pre.resultSet	{  margin: 0em 0em 0em 0em ; /* Top Right Bottom Left */
-                   padding: 0ex;
-                   font-size: 100% ;
-                   page-break-inside: avoid ; }
-pre.resultAsk	{  margin: 0em 0em 0em 0em ; /* Top Right Bottom Left */
-                   padding: 0ex;
-                   font-size: 100% ;
-                   page-break-inside: avoid ; }
-pre.resultTurtle{  margin: 0em 0em 0em 0em ; /* Top Right Bottom Left */
-                   padding: 0ex;
-                   font-size: 100% ;
-                   page-break-inside: avoid ; }
-
-pre.result	{ margin: 1em 4em 1em 0em ; }
-
-div.result	{ font-family: monospace;
-                  margin:  1em 4em 1em 0em ;
-                  padding: 1ex ; }
-
-.result table	{ border-collapse: collapse; }
-.result table td{ border-width: 1px ;
-                  border-color : black ; 
-                  font-family: monospace ;
-                  empty-cells: show;
-                  padding-left: 1ex ; padding-right: 1ex ;
-                  vertical-align:top;
-                  text-align: left ; } 
-/*  spacing: 0 ;*/
-.result table th{ border-width: 1px ;
-                  font-family: monospace ;
-                  border-color: black ;
-                  empty-cells: show;
-                  padding-left: 1ex ; padding-right: 1ex ;
-                  vertical-align:top;
-                  text-align:center; } 
-
-/* Examples : Algebra */
-div.algExample {  border: thin solid #888888;
-                  page-break-inside: avoid ;
-                  padding:0.5em ; margin:0.5em ;
-                  margin-left: 2em ; margin-right: 2em ;
-                  font-family:monospace ; }
-
-div.algExample1 { padding:0.5em ; background-color: #F0F0FF ; }
-div.algExample2 { padding:0.5em ; margin-top: 0.5em ; background-color: #F0FFF0 ; }
-
-/* Grammar Mark-up */
-.operator	{ color: #3f3f5f;
-                  text-transform: uppercase; }
-.function	{ color: #3f3f5f;
-                }
-
-/* Tuned to cope with different browsers behaviours */
-div.grammarTable table	{ border-style: solid ;
-			  border-width: 1px ;
-			  border-color: #AAA ;
-			  border-spacing: 0px ; 
-			  border-collapse: collapse ; }
-
-div.grammarTable table * { border-left-width: 0px ;
-			   border-right-width: 0px ;
-			   border-color: #AAA ; } 
-
-div.grammarTable table * tr   { border-top-style: solid ;
-			  border-top-width: 1px ;
-			  border-top-color: #AAA ; } 
-
-.grammar	{ text-align: left ;
-                  vertical-align: top ; }
-.token		{ color: #3f3f5f; }
-table.FAndOTable .token		{ color: #00c; }
-table.FAndOTable .token:visited		{ color: #a0c; }
-.gRuleHead	{ font-style: italic ;
-                  font-family: monospace ; }
-.gRuleBody	{ font-family: monospace ; }
-.gRuleLabel	{ font-family: monospace ; }
-
-.code		{ font-family: monospace; font-size: 100%; }
-pre.code	{ font-family: monospace; font-size: 100%; margin: 0 ; }
-
-/* Table of Contents */
-.toc		{ text-indent: 0; }
-DIV.toc UL UL, DIV.toc OL OL {margin-left: 0}
-DIV.toc UL UL UL, DIV.toc OL OL OL {margin-left: 1em}
-DIV.toc UL UL UL UL, DIV.toc OL OL OL OL {margin-left: 0}
-LI.tocline1	{ font-weight: bold}
-LI.tocline2	{ font-weight: normal}
-LI.tocline4	{ font-style: italic}
-/* The border in the following rule crashes NN4 on fonts.html :-(
-DIV.subtoc	{ padding: 1em; border: solid black thin; margin: 1em 0;
-                  background: #ddd} */
-DIV.toc, UL.index, DT { text-align: left; }
-
-
-/* References to the Rdf Data Model */
-span.rdfDM	{ color: #11d; }
-
-
-/* Truth Table */
-  .truth	{ font-family: monospace; }
-  .error	{ color: #ff1f1f; }
-  table.truthTable td	{ text-align: center; font-family: monospace; }
-  table.truthTable th	{ background-color: #dfdfdf; }
-  table.truthTable tbody th	{ font-weight: normal; font-family: monospace; }
-
-/* Casting table */
-table.casting	{ font-size: x-small; }
-
-.castY	{ background-color: #7FFF7F;
-                  color: black; }
-
-.castN	{ background-color: #FF7F7F;
-                  color: black; }
-
-.castM	{ background-color: white;
-                  color: black; }
-
-span.cancast:hover { background-color: #ffa;
-                     color: black; }
-
-.SPARQLoperator	{ background-color: #FFFFbf; /* yellow */
-          }
-
-.owlnonterminal {
-    font-weight: bold;
-    font-family: sans-serif;
-    font-size: 95%;
-}
-.owlgrammar {
-    margin-top: 1ex;
-    margin-bottom: 1ex;
-    padding-left: 1ex;
-    padding-right: 1ex;
-    padding-top: 1ex;
-    padding-bottom: 0.6ex;
-    border: 1px dashed #2f6fab;
-    font-family: monospace;
-}
-
-      /* ReSpec */
-      dfn { font-style: normal ; }
-      /* ReSpec */
-
-  code           { font-family: monospace; }
-
-  div.constraint,
-  div.issue,
-  div.note,
-  div.notice     { margin-left: 2em; }
-
-  ol.enumar      { list-style-type: decimal; }
-  ol.enumla      { list-style-type: lower-alpha; }
-  ol.enumlr      { list-style-type: lower-roman; }
-  ol.enumua      { list-style-type: upper-alpha; }
-  ol.enumur      { list-style-type: upper-roman; }
-
-
-  div.exampleInner pre { margin-left: 1em;
-                       margin-top: 0em; margin-bottom: 0em}
-  div.exampleOuter {border: 4px double gray;
-                  margin: 0em; padding: 0em}
-  div.exampleInner { background-color: #d5dee3;
-                   border-top-width: 4px;
-                   border-top-style: double;
-                   border-top-color: #d3d3d3;
-                   border-bottom-width: 4px;
-                   border-bottom-style: double;
-                   border-bottom-color: #d3d3d3;
-                   padding: 4px; margin: 0em }
-  div.exampleWrapper { margin: 4px }
-  div.exampleHeader { font-weight: bold;
-                    margin: 4px}
-   @media (max-width: 850px) {
-        table th, table td { font-size: 12px; padding: 3px 4px;}
-    }
-  @media (max-width: 767px) {
-     table { word-break: normal; overflow-wrap: anywhere; }
-     table tbody tr td:nth-child(4n), table tbody tr th:nth-child(4n) {max-width: 105px; overflow-wrap: anywhere; min-width: 90px;}
-  }
-    </style>
   </head>
   <body>
     <section id="abstract">
@@ -452,22 +155,21 @@ span.cancast:hover { background-color: #ffa;
         and <strong>may</strong> include a version (parameter name: <code>version</code>),
         and zero or more default graph URIs (parameter name: <code>default-graph-uri</code>) and named graph URIs (parameter name: <code>named-graph-uri</code>).
         </p>
-        
-        <p class="note" id="note-http-query">
+<p class="note" id="note-http-query">
         The HTTP QUERY method [[?RFC10008]] can be used with SPARQL queries.
         Its use should be similar to the existing definitions and guidance for using
         HTTP POST with SPARQL queries with no other SPARQL-specific requirements.
         In the following sections, where SPARQL query requests using HTTP POST are described, HTTP QUERY may also be considered
         as an acceptable though not required feature of the SPARQL 1.2 Protocol.
         </p>
-        
+
         <p>
         The response to a query request <strong>must</strong> be in a format corresponding to SPARQL Results, or RDF,
         depending on the <a data-cite="SPARQL12-QUERY#QueryForms">query form</a>
         and <a data-cite="rfc9110#content.negotiation">content negotiation</a> [[RFC9110]].
         Examples of such formats are:
         </p>
-        
+
         <ul>
         <li>SPARQL Results:
             <ul>
@@ -483,7 +185,7 @@ span.cancast:hover { background-color: #ffa;
             <li>[[[?JSON-LD11]]]</li>
             </ul></li>
         </ul>
-        
+
         <span class="doc-ref" id="query-summary"></span>
         <table style="margin-left: auto; margin-right: auto; border-color: rgb(0, 0, 0); border-collapse: collapse; padding: 5px; border: 1px">
           <tbody>
@@ -574,7 +276,7 @@ span.cancast:hover { background-color: #ffa;
             or [[[?SPARQL12-RESULTS-CSV-TSV]]]) for SPARQL Query forms <a data-cite="SPARQL12-QUERY#select">SELECT</a>
             and <a data-cite="SPARQL12-QUERY#ask">ASK</a> [[SPARQL12-QUERY]]; or,</li>
             <li>a serialized RDF graph [[RDF12-CONCEPTS]] (for example, in [[[?RDF12-TURTLE]]] or [[[?RDF12-XML]]])
-            for SPARQL Query forms <a data-cite="SPARQL12-QUERY#describe">DESCRIBE</a> 
+            for SPARQL Query forms <a data-cite="SPARQL12-QUERY#describe">DESCRIBE</a>
             and <a data-cite="SPARQL12-QUERY#construct">CONSTRUCT</a> [[SPARQL12-QUERY]].</li>
           </ul>
           <p>The content type of the response to a successful query operation must be the media type defined for the format of the response body.</p>
@@ -692,7 +394,7 @@ span.cancast:hover { background-color: #ffa;
       <p>The following HTTP trace examples illustrate invocation of the <code>query</code> and <code>update</code> operations under several different scenarios. Some example traces are abstracted
       from complete HTTP traces in these ways:</p>
       <ol>
-        <li>In some examples the string "<i>EncodedQuery</i>" represents the URL-encoded string equivalent of the SPARQL query string given in the example; the string "<i>UnencodedQuery</i>"
+        <li>In some examples the string "<code>EncodedQuery</code>" represents the URL-encoded string equivalent of the SPARQL query string given in the example; the string "<code>UnencodedQuery</code>"
         represents the exact SPARQL query string given in the example without any encoding.</li>
         <li>For <code>query</code> operation examples, only partial response bodies, containing the query results, are displayed.</li>
       </ol>
@@ -702,7 +404,7 @@ span.cancast:hover { background-color: #ffa;
           <h4>SELECT with service-supplied RDF Dataset</h4>
           <p>This SPARQL query</p>
           <div id="div-select-svcsupplied">
-            <pre class="query nohighlight">PREFIX dc: &lt;http://purl.org/dc/elements/1.1/&gt; 
+            <pre class="sparql">PREFIX dc: &lt;http://purl.org/dc/elements/1.1/&gt;
 SELECT ?book ?who 
 WHERE { ?book dc:creator ?who }</pre>
             <p>is conveyed via HTTP GET to the SPARQL query service, <code>http://www.example/sparql/</code>, as illustrated in this HTTP trace:</p>
@@ -710,7 +412,7 @@ WHERE { ?book dc:creator ?who }</pre>
 Host: www.example
 User-agent: my-sparql-client/0.1</pre>
             <p>That query against the service-supplied RDF Dataset, executed by that SPARQL query service, returns the following query result:</p>
-            <pre class="resp nohighlight">HTTP/1.1 200 OK
+            <pre class="http">HTTP/1.1 200 OK
 Date: Fri, 06 May 2005 20:55:12 GMT
 Server: Apache/1.3.29 (Unix) PHP/4.3.4 DAV/1.0.3
 Connection: close
@@ -736,7 +438,7 @@ Content-Type: application/sparql-results+xml
           <h4>SELECT with simple RDF Dataset</h4>
           <p>This SPARQL query</p>
           <div id="div-select-simple">
-            <pre class="query nohighlight">PREFIX dc: &lt;http://purl.org/dc/elements/1.1/&gt; 
+            <pre class="sparql">PREFIX dc: &lt;http://purl.org/dc/elements/1.1/&gt;
 SELECT ?book ?who 
 WHERE { ?book dc:creator ?who }</pre>
             <p>is conveyed to the SPARQL query service, <code>http://www.other.example/sparql/</code>, as illustrated in this HTTP trace:</p>
@@ -746,7 +448,7 @@ User-agent: my-sparql-client/0.1
 </pre>
             <p>That query — against the RDF Dataset identified by the value of the <code>default-graph-uri</code> parameter, <code>http://www.other.example/books</code> — executed by that SPARQL query
             service, returns the following query result:</p>
-            <pre class="resp nohighlight">HTTP/1.1 200 OK
+            <pre class="http">HTTP/1.1 200 OK
 Date: Fri, 06 May 2005 20:55:12 GMT
 Server: Apache/1.3.29 (Unix) PHP/4.3.4 DAV/1.0.3
 Connection: close
@@ -766,7 +468,7 @@ Content-Type: application/sparql-results+xml
           <h4>CONSTRUCT with simple RDF dataset and HTTP content negotiation</h4>
           <p>This SPARQL query</p>
           <div id="div-construct-simple">
-            <pre class="query nohighlight">PREFIX rdf: &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#&gt;
+            <pre class="sparql">PREFIX rdf: &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#&gt;
 PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;
 PREFIX myfoaf: &lt;http://www.example/jose/foaf.rdf#&gt;
 
@@ -784,7 +486,7 @@ Host: www.example
 User-agent: sparql-client/0.1
 Accept: text/turtle, application/rdf+xml</pre>
             <p>With the response illustrated here:</p>
-            <pre class="resp nohighlight">HTTP/1.1 200 OK
+            <pre class="http">HTTP/1.1 200 OK
 Date: Fri, 06 May 2005 20:55:11 GMT
 Server: Apache/1.3.29 (Unix)
 Connection: close
@@ -804,7 +506,7 @@ myfoaf:jose foaf:name "Jose Jimeñez";
           <h4>ASK with simple RDF Dataset</h4>
           <p>This SPARQL query</p>
           <div id="div-ask-simple">
-            <pre class="query nohighlight">PREFIX dc: &lt;http://purl.org/dc/elements/1.1/&gt; 
+            <pre class="sparql">PREFIX dc: &lt;http://purl.org/dc/elements/1.1/&gt;
 ASK WHERE { ?book dc:creator "J.K. Rowling"}</pre>
             <p>is conveyed to the SPARQL query service, <code>http://www.example/sparql/</code>, as illustrated in this HTTP trace:</p>
             <pre class="req nohighlight">GET /sparql/<b>?query=</b><i>EncodedQuery</i><b>&amp;default-graph-uri=</b>http%3A%2F%2Fwww.example%2Fbooks HTTP/1.1
@@ -812,7 +514,7 @@ Host: www.example
 User-agent: sparql-client/0.1
 </pre>
             <p>With the response illustrated here:</p>
-            <pre class="resp nohighlight">HTTP/1.1 200 OK
+            <pre class="http">HTTP/1.1 200 OK
 Date: Fri, 06 May 2005 20:48:25 GMT
 Server: Apache/1.3.29 (Unix) PHP/4.3.4 DAV/1.0.3
 Connection: close
@@ -829,14 +531,14 @@ Content-Type: application/sparql-results+xml
           <h4>DESCRIBE with simple RDF Dataset</h4>
           <p>This SPARQL query</p>
           <div id="div-describe-simple">
-            <pre class="query nohighlight">PREFIX books: &lt;http://www.example/book/&gt;
+            <pre class="sparql">PREFIX books: &lt;http://www.example/book/&gt;
 DESCRIBE books:book6</pre>
             <p>is conveyed to the SPARQL query service, <code>http://www.example/sparql/</code>, as illustrated here:</p>
             <pre class="req nohighlight">GET /sparql/<b>?query=</b><i>EncodedQuery</i><b>&amp;default-graph-uri=</b>http%3A%2F%2Fwww.example%2Fbooks HTTP/1.1
 Host: www.example
 User-agent: sparql-client/0.1</pre>
             <p>With the response illustrated here:</p>
-            <pre class="resp nohighlight">HTTP/1.1 200 OK
+            <pre class="http">HTTP/1.1 200 OK
 Date: Wed, 03 Aug 2005 12:48:25 GMT
 Server: Apache/1.3.29 (Unix) PHP/4.3.4 DAV/1.0.3
 Connection: close
@@ -857,7 +559,7 @@ Content-Type:  application/rdf+xml
           <h4>SELECT with complex RDF Dataset</h4>
           <p>This SPARQL query</p>
           <div id="div-select-complex">
-            <pre class="query nohighlight">PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;
+            <pre class="sparql">PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;
 PREFIX dc: &lt;http://purl.org/dc/elements/1.1/&gt;
 
 SELECT ?who ?g ?mbox
@@ -872,7 +574,7 @@ WHERE {  ?g dc:publisher ?who .
 Host: www.example
 User-agent: sparql-client/0.1</pre>
             <p>With the response illustrated here:</p>
-            <pre class="resp nohighlight">HTTP/1.1 200 OK
+            <pre class="http">HTTP/1.1 200 OK
 Date: Wed, 03 Aug 2005 12:48:25 GMT
 Server: Apache/1.3.29 (Unix) PHP/4.3.4 DAV/1.0.3
 Connection: close
@@ -893,7 +595,7 @@ Content-Type:  application/sparql-results+xml
           <h4>SELECT with query-only RDF Dataset</h4>
           <p>This SPARQL query</p>
           <div id="div-select-queryonly">
-            <pre class="query nohighlight">PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;
+            <pre class="sparql">PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;
 PREFIX dc: &lt;http://purl.org/dc/elements/1.1/&gt;
 
 SELECT ?who ?g ?mbox
@@ -908,7 +610,7 @@ WHERE { ?g dc:publisher ?who .
 Host: www.example
 User-agent: sparql-client/0.1</pre>
             <p>With the response illustrated here:</p>
-            <pre class="resp nohighlight">HTTP/1.1 200 OK
+            <pre class="http">HTTP/1.1 200 OK
 Date: Wed, 03 Aug 2005 12:48:25 GMT
 Server: Apache/1.3.29 (Unix) PHP/4.3.4 DAV/1.0.3
 Connection: close
@@ -924,7 +626,7 @@ Content-Type: application/sparql-results+xml
           <h4>SELECT with ambiguous RDF Dataset</h4>
           <div id="div-select-ambiguous">
             <p>This SPARQL query</p>
-            <pre class="query nohighlight">PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;
+            <pre class="sparql">PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;
 PREFIX dc: &lt;http://purl.org/dc/elements/1.1/&gt;
 
 SELECT ?who ?g ?mbox
@@ -942,7 +644,7 @@ User-agent: sparql-client/0.1</pre>
             <p>This protocol operation contains an ambiguous RDF Dataset: the dataset specified in the query is different than the one specified in the protocol (by way of
             <code>default-graph-uri</code> and <code>named-graph-uri</code> parameters). A conformant SPARQL Protocol service must resolve this ambiguity by executing the query against the RDF
             Dataset specified in the protocol:</p>
-            <pre class="resp nohighlight">HTTP/1.1 200 OK
+            <pre class="http">HTTP/1.1 200 OK
 Date: Wed, 03 Aug 2005 12:48:25 GMT
 Server: Apache/1.3.29 (Unix) PHP/4.3.4 DAV/1.0.3
 Connection: close
@@ -986,7 +688,7 @@ Content-Type: application/sparql-results+xml
           <h4>SELECT with malformed query fault</h4>
           <p>This syntactically invalid SPARQL query</p>
           <div id="div-select-malformed">
-            <pre class="query nohighlight">PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;
+            <pre class="sparql">PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;
 SELECT ?name
 WHERE { ?x foaf:name ?name
 ORDER BY ?name }</pre>
@@ -995,7 +697,7 @@ ORDER BY ?name }</pre>
 Host: www.example
 User-agent: sparql-client/0.1</pre>
             <p>With the error response illustrated here:</p>
-            <pre class="resp nohighlight">HTTP/1.1 400 Bad Request
+            <pre class="http">HTTP/1.1 400 Bad Request
 Date: Wed, 03 Aug 2005 12:48:25 GMT
 Server: Apache/1.3.29 (Unix) PHP/4.3.4 DAV/1.0.3
 Connection: close
@@ -1008,7 +710,7 @@ Content-Type: text/plain; charset=UTF-8
           <h4>SELECT with query request refused fault</h4>
           <p>This SPARQL query</p>
           <div id="div-select-refused">
-            <pre class="query nohighlight">PREFIX bio: &lt;http://bio.example/schema/#&gt;
+            <pre class="sparql">PREFIX bio: &lt;http://bio.example/schema/#&gt;
 SELECT ?valence
 FROM &lt;http://another.example/protein-db.rdf&gt;
 WHERE { ?x bio:protein ?valence }
@@ -1018,7 +720,7 @@ ORDER BY ?valence</pre>
 Host: www.example
 User-agent: sparql-client/0.1</pre>
             <p>With the error response illustrated here:</p>
-            <pre class="resp nohighlight">HTTP/1.1 500 Internal Server Error
+            <pre class="http">HTTP/1.1 500 Internal Server Error
 Date: Wed, 03 Aug 2005 12:48:25 GMT
 Server: Apache/1.3.29 (Unix) PHP/4.3.4 DAV/1.0.3
 Connection: close
@@ -1036,7 +738,7 @@ could not be retrieved within the time alloted.
           <p>Some SPARQL queries, perhaps machine generated, may be longer than can be reliably conveyed by way of the HTTP GET binding described in <a href="#query-via-get">2.1.1 query via GET</a>.
           In those cases the POST binding described in <a href="#query-via-post-urlencoded">2.1.2 query via POST with URL-encoded parameters</a> may be used. This SPARQL query</p>
           <div id="div-select-longpost">
-            <pre class="query nohighlight">PREFIX : &lt;http://www.w3.org/2002/12/cal/icaltzd#&gt;
+            <pre class="sparql">PREFIX : &lt;http://www.w3.org/2002/12/cal/icaltzd#&gt;
 PREFIX Chi: &lt;http://www.w3.org/2002/12/cal/test/Chiefs.ics#&gt;
 PREFIX New: &lt;http://www.w3.org/2002/12/cal/tzd/America/New_York#&gt;
 PREFIX xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;
@@ -1197,7 +899,7 @@ WHERE {
     }
 }</pre>
             <p>is conveyed to the SPARQL query service, <code>http://www.example/sparql/</code>, as illustrated in this HTTP trace:</p>
-            <pre class="req nohighlight">POST /sparql/ HTTP/1.1
+            <pre class="http">POST /sparql/ HTTP/1.1
 Host: www.example
 User-agent: sparql-client/0.1
 Content-Type: application/x-www-form-urlencoded
@@ -1205,7 +907,7 @@ Content-Length: 9461
 
 <b>query=</b><i>EncodedQuery</i><b>&amp;default-graph-uri=</b>http%3A%2F%2Fanother.example%2Fcalendar.rdf</pre>
             <p>With the response illustrated here:</p>
-            <pre class="resp nohighlight">HTTP/1.1 200 OK
+            <pre class="http">HTTP/1.1 200 OK
 Date: Wed, 03 Aug 2005 12:48:25 GMT
 Server: Apache/1.3.29 (Unix) PHP/4.3.4 DAV/1.0.3
 Connection: close
@@ -1246,19 +948,19 @@ Content-Type: application/sparql-results+xml
           <h4>Long SELECT query using direct POST</h4>
           <p>SPARQL queries may also be POSTed directly without URL encoding, as described in <a href="#query-via-post-direct">2.1.3 query via POST directly</a>. The same query used in the <a href=
           "#select-longpost">previous example</a> is conveyed to the SPARQL query service, <code>http://www.example/sparql/</code>, as illustrated in this HTTP trace:</p>
-          <pre class="req nohighlight">POST /sparql/?default-graph-uri=http%3A%2F%2Fanother.example%2Fcalendar.rdf HTTP/1.1
+          <pre class="http">POST /sparql/?default-graph-uri=http%3A%2F%2Fanother.example%2Fcalendar.rdf HTTP/1.1
 Host: www.example
 User-agent: sparql-client/0.1
 Content-Type: application/sparql-query
 
-<i>UnencodedQuery</i></pre>
+UnencodedQuery</pre>
           <p>With the same response as in the previous example.</p>
         </section>
         <section id="select-kanji">
           <h4>SELECT with internationalization</h4>
           <p>SPARQL queries may include internationalized characters or character sets. This SPARQL query</p>
           <div id="div-select-kanji">
-            <pre class="query nohighlight">PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;
+            <pre class="sparql">PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;
 PREFIX 食: &lt;http://www.w3.org/2001/sw/DataAccess/tests/data/i18n/kanji.ttl#&gt;
 SELECT ?name ?food 
 WHERE { [ foaf:name ?name ; 食:食べる ?food ] . }</pre>
@@ -1266,7 +968,7 @@ WHERE { [ foaf:name ?name ; 食:食べる ?food ] . }</pre>
             <pre class="req nohighlight">GET /sparql/<b>?query=</b>PREFIX%20foaf%3A%20%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%0APREFIX%20%E9%A3%9F%3A%20%3Chttp%3A%2F%2Fwww.w3.org%2F2001%2Fsw%2FDataAccess%2Ftests%2Fdata%2Fi18n%2Fkanji.ttl%23%3E%0ASELECT%20%3Fname%20%3Ffood%20%0AWHERE%20%7B%20%5B%20foaf%3Aname%20%3Fname%20%3B%20%E9%A3%9F%3A%E9%A3%9F%E3%81%B9%E3%82%8B%20%3Ffood%20%5D%20.%20%7D
 Host: www.example
 User-agent: sparql-client/0.1</pre>
-            <pre class="resp nohighlight">HTTP/1.1 200 OK
+            <pre class="http">HTTP/1.1 200 OK
 Date: Wed, 03 Aug 2005 12:48:25 GMT
 Server: Apache/1.3.29 (Unix)
 Connection: close
@@ -1282,7 +984,7 @@ Content-Type: application/sparql-results+xml
           <h4>SELECT with reified triple patterns</h4>
           <p>SPARQL queries can target reified triples. This SPARQL query</p>
           <div id="div-select-reified-triple">
-            <pre class="query nohighlight">PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;
+            <pre class="sparql">PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;
 PREFIX ex: &lt;http://example.org/&gt;
 SELECT ?name ?person
 WHERE { &lt;&lt; _:a foaf:name ?name &gt;&gt; ex:statedBy ?person . }</pre>
@@ -1290,7 +992,7 @@ WHERE { &lt;&lt; _:a foaf:name ?name &gt;&gt; ex:statedBy ?person . }</pre>
             <pre class="req nohighlight">GET /sparql/<b>?query=</b>PREFIX%20foaf%3A%20%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%0APREFIX%20ex%3A%20%3Chttp%3A%2F%2Fexample.org%2F%3E%0ASELECT%20%3Fname%20%3Fperson%0AWHERE%20%7B%20%3C%3C%28%20_%3Aa%20foaf%3Aname%20%3Fname%20%29%3E%3E%20ex%3AstatedBy%20%3Fperson%20.%20%7D<b>&version=</b>1.2
 Host: www.example
 User-agent: sparql-client/0.1</pre>
-            <pre class="resp nohighlight">HTTP/1.1 200 OK
+            <pre class="http">HTTP/1.1 200 OK
 Date: Wed, 03 Aug 2005 12:48:25 GMT
 Server: Apache/1.3.29 (Unix)
 Connection: close
@@ -1336,7 +1038,7 @@ Content-Type: application/sparql-results+xml; version=1.2
           <h4>UPDATE using URL-encoded parameters</h4>
           <p>An example request, which is a serialisation of a request sent to <code>http://localhost:8888/test</code> for the query <code>INSERT DATA { &lt;a&gt; &lt;p&gt; &lt;b&gt; }</code> is
           shown below using the URL-encoded parameter form.</p>
-          <pre class="req nohighlight">POST /test HTTP/1.1
+          <pre class="http">POST /test HTTP/1.1
 Host: localhost:8888
 Accept: text/plain
 Content-Length: 62
@@ -1348,7 +1050,7 @@ Content-Type: application/x-www-form-urlencoded
         <section id="update-direct-simple">
           <h4>UPDATE using POST directly</h4>
           <p>Update requests may be sent as a POST request with a Content-Type of <code>application/sparql-update</code>:</p>
-          <pre class="req nohighlight">POST /test HTTP/1.1
+          <pre class="http">POST /test HTTP/1.1
 Host: localhost:8888
 Accept: */*
 Content-Type: application/sparql-update
@@ -1360,7 +1062,7 @@ INSERT DATA { &lt;a&gt; &lt;p&gt; &lt;b&gt; }</pre>
           <h4>UPDATE specifying dataset and using POST directly</h4>
           <p>A dataset for an update request may be specified using the <code>using-graph-uri</code> and <code>using-named-graph-uri</code> parameters. The serialisation of an example request sent to
           <code>http://localhost:8888/test</code> and specifying a dataset with default graph <code>http://localhost:8888/people</code> is shown below.</p>
-          <pre class="req nohighlight">POST /test?using-graph-uri=http%3A%2F%2Flocalhost%3A8888%2Fpeople HTTP/1.1
+          <pre class="http">POST /test?using-graph-uri=http%3A%2F%2Flocalhost%3A8888%2Fpeople HTTP/1.1
 Host: localhost:8888
 Accept: */*
 Content-Type: application/sparql-update
@@ -1374,10 +1076,10 @@ WHERE { ?person ?property ?value ; foaf:givenName 'Fred' }</pre>
           <h4>Multi-operation UPDATE using URL-encoded parameters</h4>
           <p>A sequence of multiple operations may be included in a single request, separated by a ';' (semicolon). The serialisation of an example request sent to
           <code>http://localhost:8888/test</code> for the query</p>
-          <pre class="query nohighlight">DELETE DATA { &lt;a&gt; &lt;p&gt; &lt;old&gt; } ;
+          <pre class="sparql">DELETE DATA { &lt;a&gt; &lt;p&gt; &lt;old&gt; } ;
 INSERT DATA { &lt;a&gt; &lt;p&gt; &lt;new&gt; }</pre>
           <p>is shown below using the URL-encoded parameter form.</p>
-          <pre class="req nohighlight">POST /test HTTP/1.1
+          <pre class="http">POST /test HTTP/1.1
 Host: localhost:8888
 Accept: */*
 Content-Type: application/x-www-form-urlencoded
@@ -1389,11 +1091,11 @@ Content-Length: 130
           <h4>Multi-operation UPDATE specifying dataset and using URL-encoded parameters</h4>
           <p>When POSTing an update request with URL-encoded parameters, the dataset parameters <code>using-graph-uri</code> and <code>using-named-graph-uri</code> are specified in the POST body with
           the serialized request. The serialisation of an example request sent to <code>http://localhost:8888/test</code> for the query</p>
-          <pre class="query nohighlight">PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;
+          <pre class="sparql">PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;
 INSERT { GRAPH &lt;http://localhost:8888/people&gt; { ?person ?property ?value } }
 WHERE { GRAPH ?g { ?person ?property ?value ; foaf:givenName 'Fred' } }</pre>
           <p>and specifying a dataset with the named graphs <code>http://localhost:8888/alice/foaf.rdf</code> and <code>http://localhost:8888/eve/foaf.rdf</code> is shown below.</p>
-          <pre class="req nohighlight">POST /test HTTP/1.1
+          <pre class="http">POST /test HTTP/1.1
 Host: localhost:8888
 Accept: */*
 Content-Type: application/x-www-form-urlencoded
@@ -1406,7 +1108,7 @@ Content-Length: 130
           <h4>Multi-operation UPDATE specifying dataset and using POST directly</h4>
           <p>The serialisation of an example request sent to <code>http://localhost:8888/test</code> and specifying a dataset with the named graphs <code>http://localhost:8888/alice/foaf.rdf</code>
           and <code>http://localhost:8888/eve/foaf.rdf</code> is shown below.</p>
-          <pre class="req nohighlight">POST /test?using-named-graph-uri=http%3A%2F%2Flocalhost%3A8888%2Falice%2Ffoaf.rdf&amp;using-named-graph-uri=http%3A%2F%2Flocalhost%3A8888%2Feve%2Ffoaf.rdf HTTP/1.1
+          <pre class="http">POST /test?using-named-graph-uri=http%3A%2F%2Flocalhost%3A8888%2Falice%2Ffoaf.rdf&amp;using-named-graph-uri=http%3A%2F%2Flocalhost%3A8888%2Feve%2Ffoaf.rdf HTTP/1.1
 Host: localhost:8888
 Accept: */*
 Content-Type: application/sparql-update
@@ -1457,7 +1159,7 @@ WHERE { GRAPH ?g { ?person ?property ?value ; foaf:givenName 'Fred' } }</pre>
         <li>Section A.1: Normative References: <strong>normative</strong></li>
         <li>Section A.2: Other References: <strong>informative</strong></li>
       </ul>
-      <p>A <span class="doc-ref" id="conformant-sparql-protocol-service">conformant SPARQL Protocol service</span>:</p>
+      <p>A <dfn id="conformant-sparql-protocol-service">conformant SPARQL Protocol service</dfn>:</p>
       <ol>
         <li><strong>must</strong> implement either the <code>query</code> operation or the <code>update</code> operation in the way described in this document ("SPARQL 1.2 Protocol");</li>
         <li><strong>may</strong> implement both the <code>query</code> and <code>update</code> operations;</li>


### PR DESCRIPTION
* use http syntax highlight instead of req/resp nohighlight, it draws a box in both light and dark mode
* use default pre style for sparql, migrate to the sparql style in the hope of a syntax highlighter
* drop the style block that is unused


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-protocol/pull/33.html" title="Last updated on Jul 23, 2026, 4:40 PM UTC (244cb7d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-protocol/33/9647a21...244cb7d.html" title="Last updated on Jul 23, 2026, 4:40 PM UTC (244cb7d)">Diff</a>