### PR TITLE
Update description of normative expectations of query results.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -565,7 +565,7 @@ span.cancast:hover { background-color: #ffa;
             <li>a SPARQL Results Document (such as [[[?SPARQL12-RESULTS-XML]]], [[[?SPARQL12-RESULTS-JSON]]],
             or [[[?SPARQL12-RESULTS-CSV-TSV]]]) for SPARQL Query forms <a data-cite="SPARQL12-QUERY#select">SELECT</a>
             and <a data-cite="SPARQL12-QUERY#ask">ASK</a> [[SPARQL12-QUERY]]; or,</li>
-            <li>a serialized RDF graph [[RDF12-CONCEPTS]] (for example, in [[[?RDF12-TURTLE]]], [[[?RDF12-XML]]], or an equivalent RDF graph serialization)
+            <li>a serialized RDF graph [[RDF12-CONCEPTS]] (for example, in [[[?RDF12-TURTLE]]], [[[?RDF12-XML]]])
             for SPARQL Query forms <a data-cite="SPARQL12-QUERY#describe">DESCRIBE</a> 
             and <a data-cite="SPARQL12-QUERY#construct">CONSTRUCT</a> [[SPARQL12-QUERY]].</li>
           </ul>

--- a/spec/index.html
+++ b/spec/index.html
@@ -438,7 +438,7 @@ span.cancast:hover { background-color: #ffa;
 
        <p>Responses to an operation MAY also contain version announcements.
        The <em>SPARQL results version</em> or <em>RDF version</em> is not necessarily the same as the <em>operation version</em> specified in the request.
-       Instead, the version announcement is dependent on the response and its format, such as [[[SPARQL12-RESULTS-JSON]]] or [[[RDF12-TURTLE]]].</p>
+       Instead, the version announcement is dependent on the response and its format, such as [[[?SPARQL12-RESULTS-JSON]]] or [[[?RDF12-TURTLE]]].</p>
 
        <p>Values for the version string are discussed in <a data-cite="RDF12-CONCEPTS#defined-version-labels"></a>.</p>
       </section>
@@ -462,17 +462,17 @@ span.cancast:hover { background-color: #ffa;
         <ul>
         <li>SPARQL Results:
             <ul>
-            <li>[[[SPARQL12-RESULTS-XML]]]</li>
-            <li>[[[SPARQL12-RESULTS-JSON]]]</li>
-            <li>[[[SPARQL12-RESULTS-CSV-TSV]]]</li>
+            <li>[[[?SPARQL12-RESULTS-XML]]]</li>
+            <li>[[[?SPARQL12-RESULTS-JSON]]]</li>
+            <li>[[[?SPARQL12-RESULTS-CSV-TSV]]]</li>
             </ul></li>
         <li>RDF:
             <ul>
-            <li>[[[RDF12-N-TRIPLES]]]</li>
-            <li>[[[RDF12-TURTLE]]]</li>
-            <li>[[[RDF12-TRIG]]]</li>
-            <li>[[[RDF12-XML]]]</li>
-            <li>[[[JSON-LD11]]]</li>
+            <li>[[[?RDF12-N-TRIPLES]]]</li>
+            <li>[[[?RDF12-TURTLE]]]</li>
+            <li>[[[?RDF12-TRIG]]]</li>
+            <li>[[[?RDF12-XML]]]</li>
+            <li>[[[?JSON-LD11]]]</li>
             </ul></li>
         </ul>
         
@@ -562,10 +562,10 @@ span.cancast:hover { background-color: #ffa;
           <strong>should</strong> use a 2XX HTTP response code for a successful query, it <strong>may</strong> choose instead to use a 3XX response code as per HTTP.</p>
           <p>The response body of a successful query operation with a 2XX response is either:</p>
           <ul>
-            <li>a SPARQL Results Document (such as [[[SPARQL12-RESULTS-XML]]], [[[SPARQL12-RESULTS-JSON]]],
-            or [[[SPARQL12-RESULTS-CSV-TSV]]]) for SPARQL Query forms <a data-cite="SPARQL12-QUERY#select">SELECT</a>
+            <li>a SPARQL Results Document (such as [[[?SPARQL12-RESULTS-XML]]], [[[?SPARQL12-RESULTS-JSON]]],
+            or [[[?SPARQL12-RESULTS-CSV-TSV]]]) for SPARQL Query forms <a data-cite="SPARQL12-QUERY#select">SELECT</a>
             and <a data-cite="SPARQL12-QUERY#ask">ASK</a> [[SPARQL12-QUERY]]; or,</li>
-            <li>a serialized RDF graph [[RDF12-CONCEPTS]] (for example, in [[[RDF12-TURTLE]]], [[[RDF12-XML]]], or an equivalent RDF graph serialization)
+            <li>a serialized RDF graph [[RDF12-CONCEPTS]] (for example, in [[[?RDF12-TURTLE]]], [[[?RDF12-XML]]], or an equivalent RDF graph serialization)
             for SPARQL Query forms <a data-cite="SPARQL12-QUERY#describe">DESCRIBE</a> 
             and <a data-cite="SPARQL12-QUERY#construct">CONSTRUCT</a> [[SPARQL12-QUERY]].</li>
           </ul>

--- a/spec/index.html
+++ b/spec/index.html
@@ -470,7 +470,6 @@ span.cancast:hover { background-color: #ffa;
             <ul>
             <li>[[[?RDF12-N-TRIPLES]]]</li>
             <li>[[[?RDF12-TURTLE]]]</li>
-            <li>[[[?RDF12-TRIG]]]</li>
             <li>[[[?RDF12-XML]]]</li>
             <li>[[[?JSON-LD11]]]</li>
             </ul></li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -445,12 +445,37 @@ span.cancast:hover { background-color: #ffa;
 
       <section id="query-operation">
         <h3>Query Operation</h3>
-        <p>The <code>query</code> operation is used to send a SPARQL query to a service and receive the results of the query. The query operation <strong>must</strong> be invoked with either the HTTP
-        GET or HTTP POST method. Client requests for this operation <strong>must</strong> include exactly one SPARQL query string (parameter name: <code>query</code>) and <strong>may</strong> include a version (parameter name: <code>version</code>), and
-        zero or more default graph URIs (parameter name: <code>default-graph-uri</code>) and named graph URIs (parameter name: <code>named-graph-uri</code>). The response to a query request is either
-        the [[[SPARQL12-RESULTS-XML]]], the [[[SPARQL12-RESULTS-JSON]]], the [[[SPARQL12-RESULTS-CSV-TSV]]], or an RDF serialization, depending on the <a data-cite="SPARQL12-QUERY#QueryForms">query
-        form</a> and <a data-cite="rfc9110#content.negotiation">content negotiation</a> [[RFC9110]].
+        <p>The <code>query</code> operation is used to send a SPARQL query to a service and receive the results of the query.
+        The query operation <strong>must</strong> be invoked with either the HTTP GET or HTTP POST method.
+        Client requests for this operation <strong>must</strong> include exactly one SPARQL query string (parameter name: <code>query</code>)
+        and <strong>may</strong> include a version (parameter name: <code>version</code>),
+        and zero or more default graph URIs (parameter name: <code>default-graph-uri</code>) and named graph URIs (parameter name: <code>named-graph-uri</code>).
         </p>
+        
+        <p>
+        The response to a query request <strong>must</strong> be in a format corresponding to SPARQL Results, or RDF,
+        depending on the <a data-cite="SPARQL12-QUERY#QueryForms">query form</a>
+        and <a data-cite="rfc9110#content.negotiation">content negotiation</a> [[RFC9110]].
+        Examples of such formats are:
+        </p>
+        
+        <ul>
+        <li>SPARQL Results:
+            <ul>
+            <li>[[[SPARQL12-RESULTS-XML]]]</li>
+            <li>[[[SPARQL12-RESULTS-JSON]]]</li>
+            <li>[[[SPARQL12-RESULTS-CSV-TSV]]]</li>
+            </ul></li>
+        <li>RDF:
+            <ul>
+            <li>[[[RDF12-N-TRIPLES]]]</li>
+            <li>[[[RDF12-TURTLE]]]</li>
+            <li>[[[RDF12-TRIG]]]</li>
+            <li>[[[RDF12-XML]]]</li>
+            <li>[[[JSON-LD11]]]</li>
+            </ul></li>
+        </ul>
+        
         <span class="doc-ref" id="query-summary"></span>
         <table style="margin-left: auto; margin-right: auto; border-color: rgb(0, 0, 0); border-collapse: collapse; padding: 5px; border: 1px">
           <tbody>
@@ -537,11 +562,12 @@ span.cancast:hover { background-color: #ffa;
           <strong>should</strong> use a 2XX HTTP response code for a successful query, it <strong>may</strong> choose instead to use a 3XX response code as per HTTP.</p>
           <p>The response body of a successful query operation with a 2XX response is either:</p>
           <ul>
-            <li>a SPARQL Results Document in <a data-cite="SPARQL12-RESULTS-XML#">XML</a> [[SPARQL12-RESULTS-XML]], <a data-cite="SPARQL12-RESULTS-JSON#">JSON</a> [[SPARQL12-RESULTS-JSON]], or 
-            <a data-cite="SPARQL12-RESULTS-CSV-TSV#">CSV/TSV</a> [[SPARQL12-RESULTS-CSV-TSV]] format (for SPARQL Query forms <a data-cite="SPARQL12-QUERY#select">SELECT</a> and <a data-cite=
-            "SPARQL12-QUERY#ask">ASK</a> [[SPARQL12-QUERY]]); or,</li>
-            <li>an RDF graph [[[RDF12-CONCEPTS]]] serialized, for example, in the [[[RDF12-XML]]], or an equivalent RDF graph serialization, for SPARQL Query forms <a data-cite="SPARQL12-QUERY#describe">DESCRIBE</a> 
-            and <a data-cite="SPARQL12-QUERY#construct">CONSTRUCT</a> [[SPARQL12-QUERY]]).</li>
+            <li>a SPARQL Results Document (such as [[[SPARQL12-RESULTS-XML]]], [[[SPARQL12-RESULTS-JSON]]],
+            or [[[SPARQL12-RESULTS-CSV-TSV]]]) for SPARQL Query forms <a data-cite="SPARQL12-QUERY#select">SELECT</a>
+            and <a data-cite="SPARQL12-QUERY#ask">ASK</a> [[SPARQL12-QUERY]]; or,</li>
+            <li>a serialized RDF graph [[RDF12-CONCEPTS]] (for example, in [[[RDF12-TURTLE]]], [[[RDF12-XML]]], or an equivalent RDF graph serialization)
+            for SPARQL Query forms <a data-cite="SPARQL12-QUERY#describe">DESCRIBE</a> 
+            and <a data-cite="SPARQL12-QUERY#construct">CONSTRUCT</a> [[SPARQL12-QUERY]].</li>
           </ul>
           <p>The content type of the response to a successful query operation must be the media type defined for the format of the response body.</p>
         </section>
@@ -1440,6 +1466,7 @@ WHERE { GRAPH ?g { ?person ?property ?value ; foaf:givenName 'Fred' } }</pre>
         <li>Improve display on mobile phones</li>
         <li>Add explicit references to RFCs</li>
         <li>Use PREFIX instead of @prefix in all Turtle examples</li>
+        <li>Change normative language regarding what media types must be returned for a query request</li>
       </ul>
     </section>
     <section id="changes-1-0" class="appendix informative">

--- a/spec/index.html
+++ b/spec/index.html
@@ -565,7 +565,7 @@ span.cancast:hover { background-color: #ffa;
             <li>a SPARQL Results Document (such as [[[?SPARQL12-RESULTS-XML]]], [[[?SPARQL12-RESULTS-JSON]]],
             or [[[?SPARQL12-RESULTS-CSV-TSV]]]) for SPARQL Query forms <a data-cite="SPARQL12-QUERY#select">SELECT</a>
             and <a data-cite="SPARQL12-QUERY#ask">ASK</a> [[SPARQL12-QUERY]]; or,</li>
-            <li>a serialized RDF graph [[RDF12-CONCEPTS]] (for example, in [[[?RDF12-TURTLE]]], [[[?RDF12-XML]]])
+            <li>a serialized RDF graph [[RDF12-CONCEPTS]] (for example, in [[[?RDF12-TURTLE]]] or [[[?RDF12-XML]]])
             for SPARQL Query forms <a data-cite="SPARQL12-QUERY#describe">DESCRIBE</a> 
             and <a data-cite="SPARQL12-QUERY#construct">CONSTRUCT</a> [[SPARQL12-QUERY]].</li>
           </ul>


### PR DESCRIPTION
Changes the wording so that the expected results of a query request is any valid SPARQL results or RDF format (instead of expecting specifically SPARQL XML, JSON, or CSV/TSV in the case of SPARQL results).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kasei/sparql-protocol/pull/43.html" title="Last updated on Apr 14, 2026, 4:36 PM UTC (3760b2e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-protocol/43/b2ed7c4...kasei:3760b2e.html" title="Last updated on Apr 14, 2026, 4:36 PM UTC (3760b2e)">Diff</a>